### PR TITLE
Edit analyze.py to include users' retweets, etc

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -382,6 +382,36 @@ def analyze_timeline(user_id, list_id, api, cache):
     users = fetch_users(timeline_ids, api, cache)
     return analyze_users(users, ids_fetched=len(timeline_ids))
 
+def analyze_my_timeline(user_id, api, cache):
+    # Timeline-functions are limited to 200 statuses
+    statuses = api.GetUserTimeline(screen_name=user_id, count=200, include_rts=True, trim_user=False, exclude_replies=False)
+    maxt = 0
+    for i in range(1, 10): #end of range is exclusive so this only goes to 9, so we're looking at max 2,000 tweets
+        if not maxt == statuses[-1].id - 1: #to prevent excessive API calls if already exhausted
+            maxt = statuses[-1].id - 1
+            statuses = statuses + api.GetUserTimeline(screen_name=user_id, count=200, max_id=maxt, include_rts=True, trim_user=False, exclude_replies=False)    
+    retweet_ids = []
+    reply_ids = []
+    quotes_ids = []
+    timeline_ids = []
+    for s in statuses:
+        if s.retweeted_status is not None:
+            retweet_ids.append(s.retweeted_status.user.id)
+        elif s.in_reply_to_status_id is not None:
+            for i in s.user_mentions:
+                reply_ids.append(i.id)
+        elif s.quoted_status is not None:
+            quotes_ids.append(s.quoted_status.user.id)
+        elif len(s.user_mentions) > 0:
+            for i in s.user_mentions:
+                timeline_ids.append(i.id)
+
+    outdict = {'retweets':retweet_ids, 'replies':reply_ids, 'quotes':quotes_ids, 'mentions':timeline_ids}
+    newdict = {}
+    for ids in outdict.keys():
+        users = fetch_users(outdict.get(ids), api, cache)
+        newdict[ids] = analyze_users(users, ids_fetched=len(outdict.get(ids)))
+    return newdict
 
 # From https://github.com/bear/python-twitter/blob/master/get_access_token.py
 def get_access_token(consumer_key, consumer_secret):
@@ -486,11 +516,18 @@ if __name__ == '__main__':
         friends = analyze_friends(user_id, None, api, cache)
         followers = analyze_followers(user_id, api, cache)
         timeline = analyze_timeline(user_id, None, api, cache)
+        mytimeline = analyze_my_timeline(user_id, api, cache)
+        retweets = mytimeline.get('retweets')
+        replies = mytimeline.get('replies')
+        quotes = mytimeline.get('quotes')
+        mentions = mytimeline.get('mentions')
 
     duration = time.time() - start
 
     for user_type, an in [('friends', friends), ('followers', followers),
-                          ('timeline', timeline)]:
+                          ('timeline', timeline)
+                          ,('retweets', retweets), ('replies', replies), ('quotes', quotes), ('mentions', mentions) 
+                         ]:
         nb, men, women, andy = an.nonbinary.n, an.male.n, an.female.n, an.andy.n
 
         print("{:>25s}\t{:>10.2f}%\t{:10.2f}%\t{:10.2f}%".format(


### PR DESCRIPTION
For the command line tool, this adds sections to the report out for the gender breakdown of the users' retweets, replies, quote tweets, and other mentions (i.e., the ones that the user tweets, not ones the user sees). This might be overkill - perhaps better to collapse them all into a single "mentions/RTs/etc" category but I figured better to have more detail now, could be easy for someone else to collapse.

I made this because retweets are one of the main ways I engage with twitter and I wanted to check the gender breakdown of mine.

I've never made a pull request before so many apologies if I'm doing this wrong!

I hope that this doesn't break the website HTML; I don't think it should. I wasn't sure how to edit that to reflect this because I can't run the full code on my system.